### PR TITLE
Ignore fenced code blocks

### DIFF
--- a/md_toc/api.py
+++ b/md_toc/api.py
@@ -108,13 +108,20 @@ def build_toc(filename,
         while line:
             # Ignore lines within code fences
             # https://github.github.com/gfm/#code-fence
-            line_without_leading_spaces = line.lstrip(' ').rstrip('\n')
-            is_valid_code_fence_ident = len(line) - len(line_without_leading_spaces) <= 3
+            line_without_trailing_newline = line.rstrip('\n')
+            line_without_leading_spaces = line_without_trailing_newline.lstrip(' ')
+            is_valid_code_fence_ident = len(line_without_trailing_newline) - len(line_without_leading_spaces) <= 3
 
             if inside_code_fence:
                 line_without_leading_or_trailing_spaces = line_without_leading_spaces.rstrip(' ')
-                if is_valid_code_fence_ident and line_without_leading_spaces.startswith(closing_code_fence) and line_without_leading_or_trailing_spaces == len(line_without_leading_or_trailing_spaces) * line_without_leading_spaces[0]:
-                    inside_code_fence = False
+                is_line_homogeneous = line_without_leading_or_trailing_spaces == (
+                    len(line_without_leading_or_trailing_spaces) * line_without_leading_spaces[0]
+                )
+                inside_code_fence = not all([
+                    is_valid_code_fence_ident,
+                    line_without_leading_spaces.startswith(closing_code_fence),
+                    is_line_homogeneous
+                ])
                 line = f.readline()
                 continue
 

--- a/md_toc/api.py
+++ b/md_toc/api.py
@@ -108,7 +108,7 @@ def build_toc(filename,
         while line:
             # Ignore lines within code fences
             # https://github.github.com/gfm/#code-fence
-            line_without_leading_spaces = line.lstrip(' ')
+            line_without_leading_spaces = line.lstrip(' ').rstrip('\n')
             is_valid_code_fence_ident = len(line) - len(line_without_leading_spaces) <= 3
 
             if inside_code_fence:

--- a/md_toc/api.py
+++ b/md_toc/api.py
@@ -99,9 +99,34 @@ def build_toc(filename,
     toc = ''
     header_duplicate_counter = dict()
 
+    # Code fence state tracking
+    inside_code_fence = False
+    closing_code_fence = ''
+
     with open(filename, 'r') as f:
         line = f.readline()
         while line:
+            # Ignore lines within code fences
+            # https://github.github.com/gfm/#code-fence
+            line_without_leading_spaces = line.lstrip(' ')
+            is_valid_code_fence_ident = len(line) - len(line_without_leading_spaces) <= 3
+
+            if inside_code_fence:
+                line_without_leading_or_trailing_spaces = line_without_leading_spaces.rstrip(' ')
+                if is_valid_code_fence_ident and line_without_leading_spaces.startswith(closing_code_fence) and line_without_leading_or_trailing_spaces == len(line_without_leading_or_trailing_spaces) * line_without_leading_spaces[0]:
+                    inside_code_fence = False
+                line = f.readline()
+                continue
+
+            if is_valid_code_fence_ident and line_without_leading_spaces.startswith((3 * '`', 3 * '~')):
+                info_string = line.lstrip(line_without_leading_spaces[0])
+                if '`' not in info_string:
+                    inside_code_fence = True
+                    closing_code_fence = line.rstrip(info_string)
+                    line = f.readline()
+                    continue
+
+            # Parse headers
             header = get_md_header(line, header_duplicate_counter,
                                    keep_header_levels, parser, no_links)
             if header is not None:


### PR DESCRIPTION
Thanks for this useful tool! Here's a first pass at ignoring fenced code blocks as defined in the GFM spec. Fixes #4 

I'd like to contribute tests for this, but the `build_toc()` function is currently somewhat difficult to test because it can only take input from files. I propose a change to the api to provide a `build_toc_from_string()` function which takes the markdown content as a string. Alternatively, I can add a bunch of test case markdown files to the repo. Let me know what approach you prefer.

For now, a brief manual test:

~~~~~
[dharmab@n7 md-toc]$ cat test.md
# Foo

[](TOC)

```python
# Bar
#
## Baz
```

````
# Bar
#
## Baz
`````

~~~
# Bar
#
## Baz
~~~
[dharmab@n7 md-toc]$ md_toc github test.md 
- [Foo](#foo)
~~~~~

When I ran `make pep` on master it changed a bunch of files, so I decided not to run `make pep` to keep the diff small. It would be helpful to include a `requirements.txt` file with pinned versions of tools like yapf and flake8. I know that flake8 changes its behavior quite a bit with each release.