### PR TITLE
Split code fence detection into testable functions

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -56,6 +56,19 @@ GITHUB_LINE_BAR_BAZ = '*bar* \*baz\*'
 GITHUB_LINE_B = 'b'
 GITHUB_LINE_1000_CHARS = 1000 * 'c'
 
+BACKTICK1 = 1 * '`'
+BACKTICK2 = 2 * '`'
+BACKTICK3 = 3 * '`'
+BACKTICK4 = 4 * '`'
+BACKTICK10 = 10 * '`'
+
+TILDE1 = 1 * '~'
+TILDE2 = 2 * '~'
+TILDE3 = 3 * '~'
+TILDE4 = 4 * '~'
+TILDE10 = 10 * '~'
+
+
 # redcarpet test lines.
 REDCARPET_LINE_FOO = 'foo'
 
@@ -411,6 +424,112 @@ class TestApi(unittest.TestCase):
         other functions. None is retruned when get_md_header_type
         returns None.
         """
+
+    def test_is_opening_code_fence(self):
+        self.assertIsNone(api.is_opening_code_fence(LINE))
+        self.assertIsNone(api.is_opening_code_fence(LINE_EMPTY))
+
+        self.assertIsNone(api.is_opening_code_fence(S1))
+        self.assertIsNone(api.is_opening_code_fence(S2))
+        self.assertIsNone(api.is_opening_code_fence(S3))
+        self.assertIsNone(api.is_opening_code_fence(S4))
+        self.assertIsNone(api.is_opening_code_fence(S10))
+
+        self.assertIsNone(api.is_opening_code_fence(H1))
+        self.assertIsNone(api.is_opening_code_fence(H2))
+        self.assertIsNone(api.is_opening_code_fence(H3))
+        self.assertIsNone(api.is_opening_code_fence(H4))
+        self.assertIsNone(api.is_opening_code_fence(H5))
+        self.assertIsNone(api.is_opening_code_fence(H6))
+        self.assertIsNone(api.is_opening_code_fence(H7))
+
+        self.assertIsNone(api.is_opening_code_fence(GITHUB_LINE_FOO))
+        self.assertIsNone(api.is_opening_code_fence(GITHUB_LINE_BAR))
+        self.assertIsNone(api.is_opening_code_fence(GITHUB_LINE_FOO + LINE_NEWLINE))
+
+        self.assertIsNone(api.is_opening_code_fence(BACKTICK1))
+        self.assertIsNone(api.is_opening_code_fence(BACKTICK2))
+        self.assertIsNone(api.is_opening_code_fence(BACKTICK2 + GITHUB_LINE_FOO))
+        self.assertIsNone(api.is_opening_code_fence(BACKTICK2 + LINE_NEWLINE + BACKTICK1))
+
+        self.assertEqual(api.is_opening_code_fence(BACKTICK3), BACKTICK3)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK4), BACKTICK4)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK10), BACKTICK10)
+
+        self.assertEqual(api.is_opening_code_fence(BACKTICK3 + GITHUB_LINE_FOO), BACKTICK3)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK4 + GITHUB_LINE_FOO), BACKTICK4)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK10 + GITHUB_LINE_FOO), BACKTICK10)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK3 + GITHUB_LINE_FOO), BACKTICK3)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK4 + GITHUB_LINE_FOO), BACKTICK4)
+        self.assertEqual(api.is_opening_code_fence(BACKTICK10 + GITHUB_LINE_FOO), BACKTICK10)
+
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + BACKTICK3), BACKTICK3)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + BACKTICK4), BACKTICK4)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + BACKTICK10), BACKTICK10)
+
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + BACKTICK3 + GITHUB_LINE_FOO), BACKTICK3)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + BACKTICK4 + GITHUB_LINE_FOO), BACKTICK4)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + BACKTICK10 + GITHUB_LINE_FOO), BACKTICK10)
+
+        self.assertIsNone(api.is_opening_code_fence(BACKTICK3 + GITHUB_LINE_FOO + BACKTICK1 + GITHUB_LINE_BAR))
+
+        self.assertIsNone(api.is_opening_code_fence(TILDE1))
+        self.assertIsNone(api.is_opening_code_fence(TILDE2))
+        self.assertIsNone(api.is_opening_code_fence(TILDE2 + GITHUB_LINE_FOO))
+        self.assertIsNone(api.is_opening_code_fence(TILDE2 + LINE_NEWLINE + TILDE1))
+
+        self.assertEqual(api.is_opening_code_fence(TILDE3), TILDE3)
+        self.assertEqual(api.is_opening_code_fence(TILDE4), TILDE4)
+        self.assertEqual(api.is_opening_code_fence(TILDE10), TILDE10)
+
+        self.assertEqual(api.is_opening_code_fence(TILDE3 + GITHUB_LINE_FOO), TILDE3)
+        self.assertEqual(api.is_opening_code_fence(TILDE4 + GITHUB_LINE_FOO), TILDE4)
+        self.assertEqual(api.is_opening_code_fence(TILDE10 + GITHUB_LINE_FOO), TILDE10)
+        self.assertEqual(api.is_opening_code_fence(TILDE3 + GITHUB_LINE_FOO), TILDE3)
+        self.assertEqual(api.is_opening_code_fence(TILDE4 + GITHUB_LINE_FOO), TILDE4)
+        self.assertEqual(api.is_opening_code_fence(TILDE10 + GITHUB_LINE_FOO), TILDE10)
+
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + TILDE3), TILDE3)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + TILDE4), TILDE4)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + TILDE10), TILDE10)
+
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + TILDE3 + GITHUB_LINE_FOO), TILDE3)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + TILDE4 + GITHUB_LINE_FOO), TILDE4)
+        self.assertEqual(api.is_opening_code_fence(3 * ' ' + TILDE10 + GITHUB_LINE_FOO), TILDE10)
+
+        self.assertIsNone(api.is_opening_code_fence(TILDE1 + GITHUB_LINE_FOO + BACKTICK1 + GITHUB_LINE_BAR))
+
+    def test_is_closing_code_fence(self):
+        self.assertFalse(api.is_closing_code_fence(BACKTICK1, BACKTICK3))
+        self.assertFalse(api.is_closing_code_fence(BACKTICK2, BACKTICK3))
+
+        self.assertTrue(api.is_closing_code_fence(BACKTICK3, BACKTICK3))
+        self.assertTrue(api.is_closing_code_fence(BACKTICK4, BACKTICK3))
+        self.assertTrue(api.is_closing_code_fence(BACKTICK10, BACKTICK3))
+
+        self.assertFalse(api.is_closing_code_fence(BACKTICK3, BACKTICK4))
+        self.assertFalse(api.is_closing_code_fence(BACKTICK4, BACKTICK10))
+
+        self.assertFalse(api.is_closing_code_fence(BACKTICK3 + GITHUB_LINE_FOO, BACKTICK3))
+
+        self.assertFalse(api.is_closing_code_fence(GITHUB_LINE_FOO, BACKTICK3))
+
+        self.assertFalse(api.is_closing_code_fence(TILDE1, TILDE3))
+        self.assertFalse(api.is_closing_code_fence(TILDE2, TILDE3))
+
+        self.assertTrue(api.is_closing_code_fence(TILDE3, TILDE3))
+        self.assertTrue(api.is_closing_code_fence(TILDE4, TILDE3))
+        self.assertTrue(api.is_closing_code_fence(TILDE10, TILDE3))
+
+        self.assertFalse(api.is_closing_code_fence(TILDE3, TILDE4))
+        self.assertFalse(api.is_closing_code_fence(TILDE4, TILDE10))
+
+        self.assertFalse(api.is_closing_code_fence(TILDE3 + GITHUB_LINE_FOO, TILDE3))
+
+        self.assertFalse(api.is_closing_code_fence(GITHUB_LINE_FOO, TILDE3))
+
+        self.assertFalse(api.is_closing_code_fence(BACKTICK3, TILDE3))
+        self.assertFalse(api.is_closing_code_fence(TILDE3, BACKTICK3))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Split code fence handling into two functions, `api.is_opening_code_fence` and `api.is_closing_code_fence`. Stub out some basic, incomplete tests for each function.