### PR TITLE
reorder positional arguments in CLI for easier automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ install-dev:
 uninstall-dev:
 	pipenv --rm
 
+demo:
+	asciinema/md_toc_asciinema_2_0_0_demo.sh
+
 test:
 	pipenv run python setup.py test
 
@@ -62,4 +65,4 @@ clean:
 	rm -rf build dist *.egg-info tests/benchmark-results
 	pipenv run $(MAKE) -C docs clean
 
-.PHONY: default pep doc install install-dev uninstall uninstall-dev test benchmark dist upload clean
+.PHONY: default pep doc install install-dev uninstall uninstall-dev test benchmark dist upload clean demo

--- a/md_toc/cli.py
+++ b/md_toc/cli.py
@@ -85,14 +85,12 @@ class CliInterface():
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=textwrap.dedent(PROGRAM_EPILOG))
 
-        parser.add_argument(
-            'filename',
-            metavar='FILE_NAME',
-            nargs='*',
-            help='the I/O file name')
-
+        # markdown parser is first positional argument.
+        # File names are arguments to the subparser.
         subparsers = parser.add_subparsers(
-            dest='parser', title='markdown parser')
+            dest='parser',
+            title='markdown parser',
+            help='<markdown parser> --help')
         subparsers.required = True
 
         # github + cmark + gitlab + commonmarker.
@@ -103,6 +101,12 @@ class CliInterface():
                          option is selected, the default output will be an \
                          unordered list with the respective default values \
                          as listed below')
+        github.add_argument(
+            'filename',
+            metavar='FILE_NAME',
+            nargs='*',
+            help='the I/O file name')
+
         megroup = github.add_mutually_exclusive_group()
         megroup.add_argument(
             '-u',
@@ -144,6 +148,11 @@ class CliInterface():
                          as listed below. Gitlab rules are the same as \
                          Redcarpet except that conflicts are avoided with \
                          duplicate headers.')
+        redcarpet.add_argument(
+            'filename',
+            metavar='FILE_NAME',
+            nargs='*',
+            help='the I/O file name')
 
         megroup = redcarpet.add_mutually_exclusive_group()
         megroup.add_argument(


### PR DESCRIPTION
Before this commit
------------------

The demo script `asciinema/md_toc_asciinema_2_0_0_demo.sh`
fails with multiple errors similar to this snippet of output:

    # one of multiple errors from output of demo script
    $ md_toc github foo.md
    usage: md_toc [-h] [-c | -i] [-l] [-m TOC_MARKER] [-p] [-s SKIP_LINES] [-v]
                  [FILE_NAME [FILE_NAME ...]] {github,cmark,gitlab,commonmarker,redcarpet} ...
                  md_toc: error: argument parser: invalid choice: 'foo.md' (choose from 'github', 'cmark', 'gitlab', 'commonmarker', 'redcarpet')

`md_toc` requires the markdown parser to be the last positional argument
on the CLI. Filenames must be listed before the markdown parser.
Example:

    md_toc file1.md file2.md github

After this commit
-----------------

The demo script works.

Reorder the positional arguments so filenames come last.
Example:

    md_toc github file1.md file2.md

:warning: 3rd-party automation scripts, if any, require update
for order of positional arguments.

Arguably, this is an improvement. The implementation of markdown
parser as a subcommand means most people expect the markdown parser
to be the first positional argument. The arbitrary number of other
positional arguments typically come after the mandatory subcommand.

There are several ways to achieve the desired use case, but
this appears to be the smallest diff to do so.

Use case
--------

Generically, this commit allows `md_toc` to be used in automation
scripts that pass an unknown number of filenames to the CLI.

My specific goal is to create a hook for https://pre-commit.com/
that can be configured in yaml like:

```yaml
repos:
    - repo: https://github.com/jumanjihouse/pre-commit-hooks
      rev: latest
      hooks:
          - id: md-toc
            args: [--skip-lines, 1, --in-place, gitlab]
            types: [markdown]
```

From the above yaml, https://pre-commit.com/ uses
https://pypi.org/project/identify/ to find all markdown files in a
changeset and execute a command with filenames as last arguments:

    md_toc --skip-lines 1 --in-place gitlab [all filenames]

The significant part of this construction is that
**filenames _must be_ the last positional arguments in the command**.