### PR TITLE
Update fpyutils constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     install_requires=[
-        'fpyutils>=2.0,<2.1'
+        'fpyutils>=2.0,<3'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     install_requires=[
-        'fpyutils>=2.0,<3'
+        'fpyutils>=2.1,<3'
     ],
 )


### PR DESCRIPTION
`fpyutils` is now at 2.1 which doesn't match the current constraint.

Updating the constraint is required to allow distribution to build the packages.